### PR TITLE
feat(deploy): increase operation timeout to 120 seconds

### DIFF
--- a/app/scripts/deploy.ts
+++ b/app/scripts/deploy.ts
@@ -62,7 +62,7 @@ async function createAccount(pxe: PXE) {
 		skipPublicDeployment: true,
 	};
 	const provenInteraction = await deployMethod.prove(deployOpts);
-	await provenInteraction.send().wait({ timeout: 20 });
+	await provenInteraction.send().wait({ timeout: 120 });
 
 	await ecdsaAccount.register();
 	return ecdsaAccount.getWallet();
@@ -95,7 +95,7 @@ async function deployContract(pxe: PXE, deployer: Wallet) {
 			paymentMethod: new SponsoredFeePaymentMethod(sponsoredPFCContract.address)
 		},
 	});
-	await provenInteraction.send().wait({ timeout: 20 });
+	await provenInteraction.send().wait({ timeout: 120 });
 	await pxe.registerContract({ instance: contract, artifact: EasyPrivateVotingContract.artifact });
 
 	return {


### PR DESCRIPTION
Increased timeout values for deployment operations from 20 to 120 seconds to accommodate Aztec testnet processing times. Operations on the testnet typically take 1-2 minutes to complete, making the previous timeout insufficient.